### PR TITLE
Add bulk course retrieval

### DIFF
--- a/API/SmartAppl.Application/Interfaces/Courses/ICourseRepository.cs
+++ b/API/SmartAppl.Application/Interfaces/Courses/ICourseRepository.cs
@@ -12,6 +12,7 @@ namespace SmartAppl.Application.Interfaces.Courses
 //        IEnumerable <Course> GetAllCourses();
         Task<IEnumerable<Course>> GetAllCoursesAsync();
         Task<Course?> GetCourseByID(int id);
+        Task<IEnumerable<Course>> GetCoursesByIDAsync(IEnumerable<int> ids);
 
     }
 }

--- a/API/SmartAppl.Infrastructure/CourseRepository.cs
+++ b/API/SmartAppl.Infrastructure/CourseRepository.cs
@@ -32,5 +32,12 @@ namespace SmartAppl.Infrastructure
         {
             return await _dbContext.Courses.FindAsync(id);
         }
+
+        public async Task<IEnumerable<Course>> GetCoursesByIDAsync(IEnumerable<int> ids)
+        {
+            return await _dbContext.Courses
+                .Where(c => ids.Contains(c.CourseId))
+                .ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add async method to retrieve multiple courses by ID set
- Restore single-course lookup to original `GetCourseByID` naming

## Testing
- `dotnet test API/SmartAppl.API/SmartAppl.API.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden for package repositories)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68c148ede8a483209b8e704ca45e8ee6